### PR TITLE
Mask managing director names in preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,6 +361,11 @@
       line-height: 1.5;
     }
 
+    .preview-privacy-note {
+      color: var(--text-secondary);
+      font-style: italic;
+    }
+
     #instructions {
       display: grid;
       gap: 18px;
@@ -834,6 +839,18 @@ Part of Atlas Copco Group
 
       signaturePreview.classList.add('has-content');
       signaturePreview.innerHTML = htmlSignature;
+      maskManagingDirectorInPreview(signaturePreview);
+    }
+
+    function maskManagingDirectorInPreview(container) {
+      const managingDirectorLabel = 'Managing Director:';
+      const managingDirectorElement = Array.from(container.querySelectorAll('div')).find(div =>
+        div.textContent.trim().startsWith(managingDirectorLabel)
+      );
+
+      if (managingDirectorElement) {
+        managingDirectorElement.innerHTML = `${managingDirectorLabel} <span class="preview-privacy-note">[Verborgen in preview]</span>`;
+      }
     }
 
     function showError(field) {


### PR DESCRIPTION
## Summary
- hide the managing director names in the live preview to protect privacy while keeping exports unchanged
- add a helper style and function to replace the names with a preview-only placeholder

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e150c2fc748322bcbfdaa99db578a0