### PR TITLE
Fix build workflow dependency pin for tkhtmlview

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build desktop app
+
+on:
+  push:
+    branches:
+      - main
+      - work
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r build/requirements.txt
+
+      - name: Show dependency versions
+        run: |
+          python - <<'PY'
+import importlib
+packages = {
+    "PyInstaller": "PyInstaller",
+    "tkhtmlview": "tkhtmlview",
+}
+for display, module_name in packages.items():
+    module = importlib.import_module(module_name)
+    version = getattr(module, "__version__", getattr(module, "VERSION", "unknown"))
+    print(f"{display} version: {version}")
+PY

--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -1,0 +1,9 @@
+# Build-time dependencies for packaging the signature generator desktop app.
+# tkhtmlview 0.6.0 was requested previously, but that version was never
+# published on PyPI and breaks builds on Python 3.11. Pin to the latest
+# available release instead.
+pyinstaller>=6.0,<7.0
+# tkhtmlview only publishes up to 0.1.4 on PyPI at the time of writing.
+tkhtmlview==0.1.4
+# Pillow is a dependency of tkhtmlview with Python 3.11 compatible builds.
+Pillow>=9.5.0,<11.0.0


### PR DESCRIPTION
## Summary
- add a Windows build workflow that installs dependencies from a pinned requirements file
- pin tkhtmlview to the latest available release so Python 3.11 builds no longer fail

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f7c81b07248322aedc0bd5c768d4f2