### PR TITLE
Update head office address in signatures

### DIFF
--- a/index.html
+++ b/index.html
@@ -1198,8 +1198,7 @@ AtlasCopco(john.doe@atlascopco.com)_files\</pre>
   <hr style="border:0;border-top:1px solid #E1D6CE;margin:8px 0;">
 
   <div style="font-weight:bold; font-size:10pt;">Atlas Copco Tools Central Europe GmbH</div>
-  <div>Head Office: Atlas Copco Tools Central Europe GmbH, Langemarckstr. 35, D-45141 Essen</div>
-  <div style="color:red; font-weight:bold;">Head Office: <u>New Address as of Dec 1, 2025</u>: Wetterschacht 9, D-45139 Essen</div>
+  <div>Head Office: Atlas Copco Tools Central Europe GmbH, Wetterschacht 9, D-45139 Essen</div>
   <div>Branch Office Belgium (Atlas Copco Tools Belgium): Bremakker 45, B-3740 Bilzen</div>
   <div>Managing Director: Claus Schiedeck, Peter Edmonds</div><br>
 
@@ -1234,13 +1233,12 @@ ${title}
 
 ----------------------------------------
 Atlas Copco Tools Central Europe GmbH
-Head Office: Atlas Copco Tools Central Europe GmbH, Langemarckstr. 35, D-45141 Essen
-Head Office: New Address as of Dec 1, 2025: Wetterschacht 9, D-45139 Essen
+Head Office: Atlas Copco Tools Central Europe GmbH, Wetterschacht 9, D-45139 Essen
 Branch Office Belgium (Atlas Copco Tools Belgium): Bremakker 45, B-3740 Bilzen
 Managing Director: Claus Schiedeck, Peter Edmonds
 
 ${contactInfoText}VAT Reg.No.: DE811155641 (Germany) / BE0473470658 (Belgium)
-Company Reg. Office: HRB 5096 – Local Court Essen (Head Office) / R.C.B. 646980 - Brussels (Belgian Branch)
+ Company Reg. Office: HRB 5096 – Local Court Essen (Head Office) / R.C.B. 646980 - Brussels (Belgian Branch)
 Peppol ID (Belgium): 0208:0473470658
 
 Privacy Policy: https://www.atlascopco.com/nl-be/itba/privacy-policy
@@ -1255,12 +1253,11 @@ Part of Atlas Copco Group
 \\f0\\fs18 Best regards,\\line
 \\b\\cf1 ${escapeRtf(name)}\\b0\\line
 ${escapeRtf(title)}\\line
-\\line
-Atlas Copco Tools Central Europe GmbH\\line
-Head Office: Atlas Copco Tools Central Europe GmbH, Langemarckstr. 35, D-45141 Essen\\line
-Head Office: New Address as of Dec 1, 2025: Wetterschacht 9, D-45139 Essen\\line
-Branch Office Belgium (Atlas Copco Tools Belgium): Bremakker 45, B-3740 Bilzen\\line
-Managing Director: Claus Schiedeck, Peter Edmonds\\line
+  \\line
+  Atlas Copco Tools Central Europe GmbH\\line
+  Head Office: Atlas Copco Tools Central Europe GmbH, Wetterschacht 9, D-45139 Essen\\line
+  Branch Office Belgium (Atlas Copco Tools Belgium): Bremakker 45, B-3740 Bilzen\\line
+  Managing Director: Claus Schiedeck, Peter Edmonds\\line
 \\line
 ${contactInfoText.replace(/\n/g, "\\line ")}\\line
 VAT Reg.No.: DE811155641 (Germany) / BE0473470658 (Belgium)\\line


### PR DESCRIPTION
## Summary
- update the head office address in the HTML, text, and RTF signature templates to Wetterschacht 9, D-45139 Essen
- remove the outdated red notice about the future address change

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936d000a2d8832288ada744b737cc7c)